### PR TITLE
Fixes the parser/qparser parameter builder.

### DIFF
--- a/lib/ex_aws/cloud_search.ex
+++ b/lib/ex_aws/cloud_search.ex
@@ -611,7 +611,7 @@ defmodule ExAws.CloudSearch do
     [{"q.options", qoptions} | params]
   end
 
-  defp build_search_options({name, qparser}, params) when name in ~w(parser qparser) do
+  defp build_search_options({name, qparser}, params) when name in [:parser, :qparser] do
     [{"q.parser", qparser} | params]
   end
 


### PR DESCRIPTION
Before when you queried this, it would never add these because it would check the atoms `:parser` and `:qparser` against a word list which never matched.